### PR TITLE
Clean up After Test DBs

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -372,6 +372,7 @@ func TestReplication(t *testing.T) {
 	if _, err := client.Create(name); err != nil {
 		t.Error(err)
 	}
+	defer client.Delete(name)
 	// add some documents to database
 	db := client.Use(name)
 	for _, a := range []string{"dog", "mouse", "cat"} {
@@ -396,12 +397,7 @@ func TestReplication(t *testing.T) {
 	if !r.Ok {
 		t.Error("expected ok to be true but got false instead")
 	}
-	// remove both databases
-	for _, d := range []string{name, name2} {
-		if _, err := client.Delete(d); err != nil {
-			t.Fatal(err)
-		}
-	}
+	client.Delete(name2)
 }
 
 func TestReplicationFilter(t *testing.T) {
@@ -530,6 +526,7 @@ func TestRequest(t *testing.T) {
 	if _, err := client.Create(name); err != nil {
 		t.Fatal(err)
 	}
+	defer client.Delete(name)
 	// add some documents to database
 	db := client.Use(name)
 	animals := []string{"dog", "mouse", "cat"}
@@ -563,10 +560,6 @@ func TestRequest(t *testing.T) {
 	}
 	u := fmt.Sprintf("%s/%s", name, doc["_id"])
 	if _, err := client.Request(http.MethodPut, u, &b, "application/json"); err != nil {
-		t.Fatal(err)
-	}
-	// remove database
-	if _, err := client.Delete(name); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -909,6 +902,7 @@ func TestPurge(t *testing.T) {
 	if _, err := client.Create(dbName); err != nil {
 		t.Error(err)
 	}
+	defer client.Delete(dbName)
 	db := client.Use(dbName)
 	// create documents
 	doc := &DummyDocument{
@@ -939,10 +933,6 @@ func TestPurge(t *testing.T) {
 	if revisions[0] != postResponse.Rev {
 		t.Error("expected purged revision to be the same as posted document revision")
 	}
-	// remove database
-	if _, err := client.Delete(dbName); err != nil {
-		t.Error(err)
-	}
 }
 
 func TestSecurity(t *testing.T) {
@@ -951,6 +941,7 @@ func TestSecurity(t *testing.T) {
 	if _, err := client.Create(dbName); err != nil {
 		t.Error(err)
 	}
+	defer client.Delete(dbName)
 	db := client.Use(dbName)
 	// test putting security document first
 	secDoc := SecurityDocument{
@@ -988,10 +979,6 @@ func TestSecurity(t *testing.T) {
 	}
 	if doc.Members.Names[0] != "member1" {
 		t.Errorf("expected name member1 but got %s instead", doc.Members.Names[0])
-	}
-	// remove database
-	if _, err := client.Delete(dbName); err != nil {
-		t.Error(err)
 	}
 }
 

--- a/client_test.go
+++ b/client_test.go
@@ -414,9 +414,7 @@ func TestReplicationFilter(t *testing.T) {
 	defer func() {
 		// remove both databases
 		for _, d := range []string{dbName, dbName2} {
-			if _, err := client.Delete(d); err != nil {
-				t.Fatal(err)
-			}
+			client.Delete(d)
 		}
 	}()
 	// add some documents to database
@@ -500,9 +498,7 @@ func TestReplicationContinuous(t *testing.T) {
 	defer func() {
 		// remove both databases
 		for _, d := range []string{dbName, dbName2} {
-			if _, err := client.Delete(d); err != nil {
-				t.Fatal(err)
-			}
+			client.Delete(d)
 		}
 	}()
 	// create replication document inside _replicate database

--- a/client_test.go
+++ b/client_test.go
@@ -411,6 +411,14 @@ func TestReplicationFilter(t *testing.T) {
 	if _, err := client.Create(dbName); err != nil {
 		t.Error(err)
 	}
+	defer func() {
+		// remove both databases
+		for _, d := range []string{dbName, dbName2} {
+			if _, err := client.Delete(d); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}()
 	// add some documents to database
 	db := client.Use(dbName)
 	docs := []animal{
@@ -477,12 +485,7 @@ func TestReplicationFilter(t *testing.T) {
 	if len(allDocs.Rows) != 2 {
 		t.Errorf("expected exactly two documents but got %d instead", len(allDocs.Rows))
 	}
-	// remove both databases
-	for _, d := range []string{dbName, dbName2} {
-		if _, err := client.Delete(d); err != nil {
-			t.Fatal(err)
-		}
-	}
+
 }
 
 // test continuous replication to test getting replication document
@@ -494,6 +497,14 @@ func TestReplicationContinuous(t *testing.T) {
 	if _, err := client.Create(dbName); err != nil {
 		t.Error(err)
 	}
+	defer func() {
+		// remove both databases
+		for _, d := range []string{dbName, dbName2} {
+			if _, err := client.Delete(d); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}()
 	// create replication document inside _replicate database
 	req := ReplicationRequest{
 		Document: Document{
@@ -514,12 +525,7 @@ func TestReplicationContinuous(t *testing.T) {
 	if tasks[0].Type != "replication" {
 		t.Errorf("expected type replication but got %s instead", tasks[0].Type)
 	}
-	// remove both databases
-	for _, d := range []string{dbName, dbName2} {
-		if _, err := client.Delete(d); err != nil {
-			t.Fatal(err)
-		}
-	}
+
 }
 
 func TestRequest(t *testing.T) {
@@ -585,6 +591,8 @@ func TestDocumentPost(t *testing.T) {
 	if _, err := client.Create(name); err != nil {
 		t.Error(err)
 	}
+	defer client.Delete(name)
+
 	db := client.Use(name)
 	// use database
 	doc := &DummyDocument{
@@ -602,10 +610,6 @@ func TestDocumentPost(t *testing.T) {
 	if !res.Ok {
 		t.Error("expected ok to be true but got false instead")
 	}
-	// remove database
-	if _, err := client.Delete(name); err != nil {
-		t.Fatal(err)
-	}
 }
 
 func TestDocumentHead(t *testing.T) {
@@ -617,6 +621,7 @@ func TestDocumentHead(t *testing.T) {
 	if _, err := client.Create(name); err != nil {
 		t.Error(err)
 	}
+	defer client.Delete(name)
 	db := client.Use(name)
 	// create document
 	doc := &DummyDocument{
@@ -646,6 +651,7 @@ func TestDocumentGet(t *testing.T) {
 	if _, err := client.Create(name); err != nil {
 		t.Error(err)
 	}
+	defer client.Delete(name)
 	db := client.Use(name)
 	// create document
 	doc := &DummyDocument{
@@ -680,6 +686,7 @@ func TestDocumentPut(t *testing.T) {
 	if _, err := client.Create(name); err != nil {
 		t.Error(err)
 	}
+	defer client.Delete(name)
 	db := client.Use(name)
 	// create document
 	doc := &DummyDocument{
@@ -720,6 +727,7 @@ func TestDocumentDelete(t *testing.T) {
 	if _, err := client.Create(name); err != nil {
 		t.Error(err)
 	}
+	defer client.Delete(name)
 	db := client.Use(name)
 	// create document
 	doc := &DummyDocument{
@@ -759,6 +767,7 @@ func TestDocumentPutAttachment(t *testing.T) {
 	if _, err := client.Create(name); err != nil {
 		t.Error(err)
 	}
+	defer client.Delete(name)
 	db := client.Use(name)
 	doc := &DummyDocument{
 		Document: Document{
@@ -790,6 +799,7 @@ func TestUpdateDocumentWithAttachment(t *testing.T) {
 	if _, err := client.Create(name); err != nil {
 		t.Error(err)
 	}
+	defer client.Delete(name)
 	db := client.Use(name)
 	doc := &DummyDocument{
 		Document: Document{
@@ -829,6 +839,7 @@ func TestDocumentBulkDocs(t *testing.T) {
 	if _, err := client.Create(name); err != nil {
 		t.Error(err)
 	}
+	defer client.Delete(name)
 	db := client.Use(name)
 	// first dummy document
 	doc1 := &DummyDocument{
@@ -863,6 +874,7 @@ func TestAllDocs(t *testing.T) {
 	if _, err := client.Create(name); err != nil {
 		t.Error(err)
 	}
+	defer client.Delete(name)
 	db := client.Use(name)
 	// first dummy document
 	doc1 := &DummyDocument{
@@ -1013,6 +1025,7 @@ func TestView(t *testing.T) {
 	if _, err := client.Create(name); err != nil {
 		t.Error(err)
 	}
+	defer client.Delete(name)
 	db := client.Use(name)
 	// create database
 	design := &DesignDocument{
@@ -1269,10 +1282,6 @@ func TestView(t *testing.T) {
 		}
 	})
 
-	// remove database
-	if _, err := client.Delete(name); err != nil {
-		t.Error(err)
-	}
 }
 
 // mimeType()
@@ -1724,6 +1733,7 @@ func TestSeed(t *testing.T) {
 	if _, err := client.Create(name); err != nil {
 		t.Error(err)
 	}
+	defer client.Delete(name)
 	db := client.Use(name)
 	docs, err := client.Parse(filepath.Join("example", "design"))
 	if err != nil {


### PR DESCRIPTION
Cleans up test dbs created during tests.
Moves current "deletes" to defer after creation, which prevents orphan dbs from being left behind when a test errors out.